### PR TITLE
[Feature Request] Add log-only mode

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@ NETWORK="bitcoin"
 LND_DIR="/home/umbrel/umbrel/lnd"
 SOCKET="localhost:10009"
 API_KEY="YOUR_TELEGRAM_API_KEY"
+LOG_TO_FILE_ONLY=false


### PR DESCRIPTION
- New setting in .env file: LOG_TO_FILE_ONLY (true/false; false=default)
- if true: don't start bot, log only hits (insufficient balance) to file (failurelogs.json)

Needs further testing of default mode. I only tested log-only mode. 
Quick'n'dirty proposal, did not edit SRC files.